### PR TITLE
Fix Replacement of Primitive Points

### DIFF
--- a/NoiseLib/include/noise.h
+++ b/NoiseLib/include/noise.h
@@ -1660,7 +1660,7 @@ double Noise<I>::ComputeColorPrimitives(double x, double y, const Cell& higherRe
 	{
 		Cell newCell = GetCell(x, y, 2 * highestResCell.resolution);
 		Point2DArray<N> newPoints = GenerateNeighboringPoints<N>(newCell);
-		ReplaceNeighboringPoints(highestResCell, higherResPoints, newCell, newPoints);
+		ReplaceNeighboringPoints(highestResCell, highestResPoints, newCell, newPoints);
 
 		highestResCell = newCell;
 		highestResPoints = newPoints;


### PR DESCRIPTION
Correctly use the previous primitives level to replace the points of the next.